### PR TITLE
fix: stream parser escape handling for strings ending with backslash

### DIFF
--- a/lwjson/src/include/lwjson/lwjson.h
+++ b/lwjson/src/include/lwjson/lwjson.h
@@ -232,7 +232,7 @@ typedef struct lwjson_stream_parser {
         /* Todo: Add other types */
     } data; /*!< Data union used to parse various */
 
-    char prev_c; /*!< History of characters */
+    uint8_t is_escaped; /*!< Set to 1 when backslash escape is active in string parsing */
 } lwjson_stream_parser_t;
 
 lwjsonr_t lwjson_stream_init(lwjson_stream_parser_t* jsp, lwjson_stream_parser_callback_fn evt_fn);

--- a/lwjson/src/lwjson/lwjson_stream.c
+++ b/lwjson/src/lwjson/lwjson_stream.c
@@ -158,6 +158,7 @@ lwjsonr_t
 lwjson_stream_reset(lwjson_stream_parser_t* jsp) {
     jsp->parse_state = LWJSON_STREAM_STATE_WAITINGFIRSTCHAR;
     jsp->stack_pos = 0;
+    jsp->is_escaped = 0;
     return lwjsonOK;
 }
 
@@ -293,6 +294,7 @@ start_over:
                 }
 #endif /* defined(LWJSON_DEV) */
                 jsp->parse_state = LWJSON_STREAM_STATE_PARSING_STRING;
+                jsp->is_escaped = 0;
                 LWJSON_MEMSET(&jsp->data.str, 0x00, sizeof(jsp->data.str));
 
             } else if (prv_stack_get_top(jsp) == LWJSON_STREAM_TYPE_OBJECT) {
@@ -356,13 +358,15 @@ start_over:
         case LWJSON_STREAM_STATE_PARSING_STRING: {
             lwjson_stream_type_t type = prv_stack_get_top(jsp);
 
-            /* 
-             * Quote character may trigger end of string, 
-             * or if backslasled before - it is part of string
-             * 
-             * TODO: Handle backslash
+            /*
+             * If previous character was an unescaped backslash,
+             * current character is part of an escape sequence.
+             * Clear the flag and fall through to store it normally.
              */
-            if (chr == '"' && jsp->prev_c != '\\') {
+            if (jsp->is_escaped) {
+                jsp->is_escaped = 0;
+            } else if (chr == '"') {
+                /* Unescaped quote terminates the string */
 #if defined(LWJSON_DEV)
                 if (type == LWJSON_STREAM_TYPE_OBJECT) {
                     LWJSON_DEBUG(jsp, "End of string parsing - object key name: \"%s\"\r\n", jsp->data.str.buff);
@@ -406,24 +410,28 @@ start_over:
                     SEND_EVT(jsp, LWJSON_STREAM_TYPE_STRING);
                     jsp->stack[jsp->stack_pos - 1].meta.index++;
                 }
-            } else {
-                /* TODO: Check other backslash elements */
-                jsp->data.str.buff[jsp->data.str.buff_pos++] = chr;
-                jsp->data.str.buff_total_pos++;
+                break;
+            } else if (chr == '\\') {
+                /* Backslash starts an escape sequence */
+                jsp->is_escaped = 1;
+            }
 
-                /* Handle buffer "overflow" */
-                if (jsp->data.str.buff_pos >= (sizeof(jsp->data.str.buff) - 1)) {
-                    jsp->data.str.buff[jsp->data.str.buff_pos] = '\0';
+            /* Store character in buffer (escaped chars, backslash, and normal chars) */
+            jsp->data.str.buff[jsp->data.str.buff_pos++] = chr;
+            jsp->data.str.buff_total_pos++;
 
-                    /* 
-                     * - For array or key types - following one is always string
-                     * - For object type - character is key
-                     */
-                    SEND_EVT(jsp, (type == LWJSON_STREAM_TYPE_KEY || type == LWJSON_STREAM_TYPE_ARRAY)
-                                      ? LWJSON_STREAM_TYPE_STRING
-                                      : LWJSON_STREAM_TYPE_KEY);
-                    jsp->data.str.buff_pos = 0;
-                }
+            /* Handle buffer "overflow" */
+            if (jsp->data.str.buff_pos >= (sizeof(jsp->data.str.buff) - 1)) {
+                jsp->data.str.buff[jsp->data.str.buff_pos] = '\0';
+
+                /*
+                 * - For array or key types - following one is always string
+                 * - For object type - character is key
+                 */
+                SEND_EVT(jsp, (type == LWJSON_STREAM_TYPE_KEY || type == LWJSON_STREAM_TYPE_ARRAY)
+                                  ? LWJSON_STREAM_TYPE_STRING
+                                  : LWJSON_STREAM_TYPE_KEY);
+                jsp->data.str.buff_pos = 0;
             }
             break;
         }
@@ -497,6 +505,5 @@ start_over:
 
         default: break;
     }
-    jsp->prev_c = chr; /* Save current c as previous for next round */
     return lwjsonSTREAMINPROG;
 }

--- a/tests/test_stream/test_stream.c
+++ b/tests/test_stream/test_stream.c
@@ -232,5 +232,28 @@ test_run(void) {
     RUN_TEST(parsed_data.event_counter == num_expected_events);
     RUN_TEST(!parsed_data.event_error);
 
+    /*
+     * Verify strings ending with escaped backslash parse correctly
+     * and do not cause the parser to miss the closing quote.
+     */
+    {
+        static const char* escaped_bs_tests[] = {
+            "{\"a\":\"\\\\\"}", /* {"a":"\\"} - string is single backslash */
+            "{\"a\":\"\\\\\\\\\"}", /* {"a":"\\\\"} - string is two backslashes */
+            "{\"a\":\"\\\\\\\"\"}", /* {"a":"\\\"} - escaped bs then escaped quote */
+            "{\"a\":\"hello\\\\\"}", /* {"a":"hello\\"} */
+            NULL,
+        };
+        for (const char** tc = escaped_bs_tests; *tc != NULL; ++tc) {
+            lwjson_stream_init(&parser, prv_parser_callback);
+            const char* p = *tc;
+            lwjsonr_t res = lwjsonSTREAMINPROG;
+            while (*p && res == lwjsonSTREAMINPROG) {
+                res = lwjson_stream_parse(&parser, *p++);
+            }
+            RUN_TEST(res == lwjsonSTREAMDONE);
+        }
+    }
+
     return test_failed > 0 ? -1 : 0;
 }


### PR DESCRIPTION
This should fix issue with backslash that can cause program to hang on input like `"{\"a\":\"\\\\\"}"`