### PR TITLE
Add configurable 32-bit serializer integer support

### DIFF
--- a/lwjson/src/include/lwjson/lwjson_opt.h
+++ b/lwjson/src/include/lwjson/lwjson_opt.h
@@ -156,6 +156,16 @@ extern "C" {
 #endif
 
 /**
+ * \brief           Enables `1` or disables `0` 64-bit integer serializer APIs
+ *
+ * Set to `0` on targets without 64-bit integer support. In that mode,
+ * serializer integer APIs use `int32_t` and `uint32_t`.
+ */
+#ifndef LWJSON_CFG_SERIALIZER_USE_64BIT
+#define LWJSON_CFG_SERIALIZER_USE_64BIT 1
+#endif
+
+/**
  * \}
  */
 

--- a/lwjson/src/include/lwjson/lwjson_serializer.h
+++ b/lwjson/src/include/lwjson/lwjson_serializer.h
@@ -89,6 +89,24 @@ typedef struct {
     lwjson_serializer_default_ctx_t default_ctx; /*!< Default context for buffered output */
 } lwjson_serializer_t;
 
+/**
+ * \brief           Unsigned integer type used by serializer integer APIs
+ */
+#if LWJSON_CFG_SERIALIZER_USE_64BIT
+typedef uint64_t lwjson_serializer_uint_t;
+#else
+typedef uint32_t lwjson_serializer_uint_t;
+#endif
+
+/**
+ * \brief           Signed integer type used by serializer integer APIs
+ */
+#if LWJSON_CFG_SERIALIZER_USE_64BIT
+typedef int64_t lwjson_serializer_int_t;
+#else
+typedef int32_t lwjson_serializer_int_t;
+#endif
+
 lwjsonr_t lwjson_serializer_init(lwjson_serializer_t* serializer, char* user_buffer, size_t buffer_size);
 lwjsonr_t lwjson_serializer_finalize(lwjson_serializer_t* serializer, size_t* total_length);
 lwjsonr_t lwjson_serializer_init_callback(lwjson_serializer_t* serializer, lwjson_serializer_callback_fn callback,
@@ -99,8 +117,10 @@ lwjsonr_t lwjson_serializer_end_object(lwjson_serializer_t* serializer);
 lwjsonr_t lwjson_serializer_end_array(lwjson_serializer_t* serializer);
 lwjsonr_t lwjson_serializer_add_string(lwjson_serializer_t* serializer, const char* key, size_t key_len,
                                        const char* value, size_t value_len);
-lwjsonr_t lwjson_serializer_add_uint(lwjson_serializer_t* serializer, const char* key, size_t key_len, uint64_t value);
-lwjsonr_t lwjson_serializer_add_int(lwjson_serializer_t* serializer, const char* key, size_t key_len, int64_t value);
+lwjsonr_t lwjson_serializer_add_uint(lwjson_serializer_t* serializer, const char* key, size_t key_len,
+                                     lwjson_serializer_uint_t value);
+lwjsonr_t lwjson_serializer_add_int(lwjson_serializer_t* serializer, const char* key, size_t key_len,
+                                    lwjson_serializer_int_t value);
 lwjsonr_t lwjson_serializer_add_float(lwjson_serializer_t* serializer, const char* key, size_t key_len, double value);
 lwjsonr_t lwjson_serializer_add_bool(lwjson_serializer_t* serializer, const char* key, size_t key_len, uint8_t value);
 lwjsonr_t lwjson_serializer_add_null(lwjson_serializer_t* serializer, const char* key, size_t key_len);

--- a/lwjson/src/lwjson/lwjson_serializer.c
+++ b/lwjson/src/lwjson/lwjson_serializer.c
@@ -465,12 +465,17 @@ lwjson_serializer_add_string(lwjson_serializer_t* serializer, const char* key, s
  * \return          \ref lwjsonOK on success, member of \ref lwjsonr_t otherwise
  */
 lwjsonr_t
-lwjson_serializer_add_uint(lwjson_serializer_t* serializer, const char* key, size_t key_len, uint64_t value) {
-    char number_str[32]; /* Large enough for uint64_t */
+lwjson_serializer_add_uint(lwjson_serializer_t* serializer, const char* key, size_t key_len,
+                           lwjson_serializer_uint_t value) {
+    char number_str[32]; /* Large enough for a 64-bit unsigned integer */
     int32_t num_len;
 
     /* Convert number to string */
+#if LWJSON_CFG_SERIALIZER_USE_64BIT
     num_len = snprintf(number_str, sizeof(number_str), "%" PRIu64, value);
+#else
+    num_len = snprintf(number_str, sizeof(number_str), "%" PRIu32, value);
+#endif
     if (num_len < 0) {
         return lwjsonERRINVAL;
     }
@@ -491,12 +496,17 @@ lwjson_serializer_add_uint(lwjson_serializer_t* serializer, const char* key, siz
  * \return          \ref lwjsonOK on success, member of \ref lwjsonr_t otherwise
  */
 lwjsonr_t
-lwjson_serializer_add_int(lwjson_serializer_t* serializer, const char* key, size_t key_len, int64_t value) {
-    char number_str[32]; /* Large enough for int64_t */
+lwjson_serializer_add_int(lwjson_serializer_t* serializer, const char* key, size_t key_len,
+                          lwjson_serializer_int_t value) {
+    char number_str[32]; /* Large enough for a 64-bit signed integer */
     int32_t num_len;
 
     /* Convert number to string */
+#if LWJSON_CFG_SERIALIZER_USE_64BIT
     num_len = snprintf(number_str, sizeof(number_str), "%" PRId64, value);
+#else
+    num_len = snprintf(number_str, sizeof(number_str), "%" PRId32, value);
+#endif
     if (num_len < 0) {
         return lwjsonERRINVAL;
     }


### PR DESCRIPTION
Adds LWJSON_CFG_SERIALIZER_USE_64BIT to configure the integer width used by the JSON serializer API.

Setting the option to 0 makes lwjson_serializer_add_uint and lwjson_serializer_add_int use uint32_t and int32_t. The default remains 64-bit for backward compatibility.

This supports targets using newlib-nano, whose lightweight formatter does not support 64-bit printf format macros such as PRIu64 and PRId64.